### PR TITLE
Add a rule to avoid cleaning ids broken sprite svg

### DIFF
--- a/webpack/build.config.js
+++ b/webpack/build.config.js
@@ -74,6 +74,13 @@ module.exports = {
               gifsicle: {
                 interlaced: false,
               },
+              svgo: {
+                plugins: [
+                  {
+                    cleanupIDs: false,
+                  },
+                ],
+              },
             },
           },
         ],


### PR DESCRIPTION
By using this rule, you avoid the cleanup of ids which broke the svg when you build with image webpack loader.